### PR TITLE
renaming gitea-$ver-linux-$arch to gitea

### DIFF
--- a/apps/Gitea.sh
+++ b/apps/Gitea.sh
@@ -28,7 +28,7 @@ case $ARCH in
 esac
 
 # Download the archive
-download "https://dl.gitea.io/gitea/$ver/gitea-$ver-linux-$arch" "Downloading the Gitea $ver binary..."
+download "https://dl.gitea.io/gitea/$ver/gitea-$ver-linux-$arch -O /home/git/gitea/gitea" "Downloading the Gitea $ver binary..."
 
 # Start the service and enable it to start up at boot
 download "https://raw.githubusercontent.com/go-gitea/gitea/master/scripts/systemd/gitea.service -O /etc/systemd/system/gitea.service" "Downloading the Gitea systemd service..."


### PR DESCRIPTION
In gitea.service, the exec is (correctly) /home/git/gitea/gitea web but the downloaded binary was not renamed to gitea and the ervice could not start.  Running the script - as of today - would only lead to gitea-1.0.1-linux-amd64 in the /home/git/gitea/ folder. 

I hope I am right and that this helps.