### PR TITLE
Fix for Syntax error: "fi" unexpected (expecting "then")

### DIFF
--- a/apps/Rocket.Chat.sh
+++ b/apps/Rocket.Chat.sh
@@ -65,7 +65,7 @@ mkdir -p /var/www/rocketchat
 cd /var/www/rocketchat
 
 # Dependencies needed for npm install
-if [ $ARCH = arm64 ]
+if [ $ARCH = arm64 ]; then
   [ $PKG = rpm ] && $install gcc-c++ || $install g++
   $install python make
 fi


### PR DESCRIPTION
When using ubuntu/trusty64 rocket.chat can´t be installed.
After zhis fix, it works