### PR TITLE
Fix seafile-server-installer link (should not go to syncwerk's repo)

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,7 +40,7 @@
 - [Syncthing](https://syncthing.net/) - Open Source Continuous File Synchronization
 - [OpenVPN](https://openvpn.net/) - Open source secure tunneling VPN daemon - Deployed thanks to [openvpn-install](https://github.com/Nyr/openvpn-install)
 - [Mumble](http://www.mumble.info/) - Voicechat utility
-- [Seafile](https://seafile.com) - Cloud storage with file encryption and group sharing - MariaDB version deployed thanks to [seafile-server-installer](https://github.com/SeafileDE/seafile-server-installer)
+- [Seafile](https://seafile.com) - Cloud storage with file encryption and group sharing - MariaDB version deployed thanks to [seafile-server-installer](https://github.com/haiwen/seafile-server-installer)
 - [Mopidy](https://www.mopidy.com/) - Mopidy plays music from local disk, Spotify, SoundCloud, Google Play Music, and more - With [Mopify](https://github.com/dirkgroenen/mopidy-mopify) - Web Client for Mopidy Music Server and the Pi MusicBox
 - [FreshRSS](http://freshrss.org/) - A free, self-hosted RSS feed aggregator. Lightweight, easy to work with, powerful and customizable
 - [OwnCloud](https://owncloud.org/) - Access & share your files, calendars, contacts, mail & more from any device, on your terms


### PR DESCRIPTION
The current link redirects to Syncwerk's installer. The Syncwerk repository is separate from the official Seafile one. I have replaced the link to redirect to Seafile's source code repository. The link to the repo is a good reference, especially if someone wants to install Seafile Pro using this tool.